### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a git repo for the cadence contrats for versus@flow. Follow the guide be
 ## How to run the sample
 
 Start two terminals. Both from the root directory.
- - `flow project start-emualator -v`
+ - `flow project start-emulator -v`
 - `make demo`
 
 ## What happends in the sample

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a git repo for the cadence contrats for versus@flow. Follow the guide be
 ## How to run the sample
 
 Start two terminals. Both from the root directory.
- - `flow project start-emulator -v`
+ - `flow emulator -v`
 - `make demo`
 
 ## What happends in the sample


### PR DESCRIPTION
Two small changes to the readme - a typo and a deprecation warning returned by the Flow CLI.