### PR TITLE
Essential fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 flowdb
+.idea

--- a/contracts/Auction.cdc
+++ b/contracts/Auction.cdc
@@ -21,6 +21,7 @@ pub contract Auction {
         pub let endTime : Fix64
         pub let startTime : Fix64
         pub let metadata: Art.Metadata?
+        pub let artId: UInt64?
         pub let owner: Address
         pub let leader: Address?
         pub let minNextBid: UFix64
@@ -33,6 +34,7 @@ pub contract Auction {
             active: Bool, 
             timeRemaining:Fix64, 
             metadata: Art.Metadata?,
+            artId: UInt64?,
             leader:Address?, 
             bidIncrement: UFix64,
             owner: Address, 
@@ -48,6 +50,7 @@ pub contract Auction {
             self.active=active
             self.timeRemaining=timeRemaining
             self.metadata=metadata
+            self.artId=artId
             self.leader= leader
             self.bidIncrement=bidIncrement
             self.owner=owner
@@ -298,6 +301,7 @@ pub contract Auction {
                 active: !self.auctionCompleted  && !self.isAuctionExpired(),
                 timeRemaining: self.timeRemaining(),
                 metadata: self.NFT?.metadata,
+                artId: self.NFT?.id,
                 leader: leader,
                 bidIncrement: self.minimumBidIncrement,
                 owner: self.ownerVaultCap.borrow()!.owner!.address,

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -63,7 +63,7 @@ pub contract Versus {
         access(contract) var firstBidBlock: UInt64?
         access(contract) var settledAt: UInt64?
 
-        access(contract) var extentionOnLateBid: UFix64
+        access(contract) var extensionOnLateBid: UFix64
         access(contract) var contentId: UInt64
         access(contract) var contentCapability: Capability<&Content.Collection>
 
@@ -81,7 +81,7 @@ pub contract Versus {
             self.firstBidBlock=nil
             self.settledAt=nil
             self.metadata=self.uniqueAuction.getAuctionStatus().metadata!
-            self.extentionOnLateBid=extentionOnLateBid
+            self.extensionOnLateBid=extensionOnLateBid
             self.contentId=contentId
             self.contentCapability=contentCapability
         }
@@ -223,7 +223,7 @@ pub contract Versus {
                 panic("This drop has ended")
             }
            
-            let bidEndTime = time + Fix64(self.extentionOnLateBid)
+            let bidEndTime = time + Fix64(self.extensionOnLateBid)
 
             //we save the time of the first bid so that it can be used to fetch events from that given block
             if self.firstBidBlock == nil {
@@ -381,7 +381,7 @@ pub contract Versus {
              vaultCap: Capability<&{FungibleToken.Receiver}>, 
              artAdmin: &Art.Administrator,
              duration: UFix64, 
-             extentionOnLateBid:UFix64)
+             extensionOnLateBid:UFix64)
 
         pub fun settle(_ dropId: UInt64)
     }
@@ -422,7 +422,7 @@ pub contract Versus {
              vaultCap: Capability<&{FungibleToken.Receiver}>, 
              artAdmin: &Art.Administrator, 
              duration: UFix64, 
-             extentionOnLateBid:UFix64) {
+             extensionOnLateBid:UFix64) {
 
             pre {
                 vaultCap.check() == true : "Vault capability should exist"
@@ -466,7 +466,7 @@ pub contract Versus {
             let drop  <- create Drop(
                 uniqueAuction: <- item, 
                 editionAuctions:  <- editionedAuctions, 
-                extentionOnLateBid: extentionOnLateBid, 
+                extensionOnLateBid: extensionOnLateBid, 
                 contentId: contentId, 
                 contentCapability: contentCapability)
             emit DropCreated(name: metadata.name, artist: metadata.artist,  editions: editions, owner: vaultCap.borrow()!.owner!.address, dropId: drop.dropID)

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -113,6 +113,19 @@ pub contract Versus {
                 difference=uniqueStatus.price - editionPrice
                 winningStatus="UNIQUE"
             }
+
+            let block=getCurrentBlock()
+            let time=Fix64(block.timestamp)
+
+            var started = uniqueStatus.startTime < time 
+            var active=true
+            if !started {
+                active=false
+            } else if uniqueStatus.completed {
+                active=false
+            } else if uniqueStatus.expired && winningStatus != "TIE" {
+                active=false
+            }
             
             return DropStatus(
                 dropId: self.dropID,
@@ -123,7 +136,8 @@ pub contract Versus {
                 firstBidBlock: self.firstBidBlock,
                 difference: difference,
                 metadata: self.metadata,
-                settledAt: self.settledAt
+                settledAt: self.settledAt,
+                active: active
             )
         }
 
@@ -297,7 +311,8 @@ pub contract Versus {
             firstBidBlock:UInt64?,
             difference:UFix64,
             metadata: Art.Metadata,
-            settledAt: UInt64?
+            settledAt: UInt64?,
+            active: Bool
             ) {
                 self.dropId=dropId
                 self.uniqueStatus=DropAuctionStatus(uniqueStatus)
@@ -307,7 +322,7 @@ pub contract Versus {
                 self.endTime=uniqueStatus.endTime
                 self.startTime=uniqueStatus.startTime
                 self.timeRemaining=uniqueStatus.timeRemaining
-                self.active=uniqueStatus.active
+                self.active=active
                 self.winning=status
                 self.firstBidBlock=firstBidBlock
                 self.difference=difference

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -140,7 +140,8 @@ pub contract Versus {
                 difference: difference,
                 metadata: self.metadata,
                 settledAt: self.settledAt,
-                active: active
+                active: active,
+                artId: uniqueStatus.artId
             )
         }
 
@@ -303,6 +304,7 @@ pub contract Versus {
         pub let settled: Bool
         pub let expired: Bool
         pub let settledAt: UInt64?
+        pub let artId: UInt64?
 
         init(
             dropId: UInt64,
@@ -313,8 +315,9 @@ pub contract Versus {
             firstBidBlock:UInt64?,
             difference:UFix64,
             metadata: Art.Metadata,
-            settledAt: UInt64?,
-            active: Bool
+            settledAt: UInt64?
+            active: Bool,
+            artId: UInt64?
             ) {
                 self.dropId=dropId
                 self.uniqueStatus=DropAuctionStatus(uniqueStatus)
@@ -332,7 +335,7 @@ pub contract Versus {
                 self.settled=uniqueStatus.completed
                 self.expired=uniqueStatus.expired
                 self.settledAt=settledAt
-
+                self.artId=artId
             }
     }
 

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -69,7 +69,7 @@ pub contract Versus {
 
         init( uniqueAuction: @Auction.AuctionItem, 
             editionAuctions: @Auction.AuctionCollection, 
-            extentionOnLateBid: UFix64,
+            extensionOnLateBid: UFix64,
             contentId: UInt64,
             contentCapability: Capability<&Content.Collection>) { 
 

--- a/tasks/demo/main.go
+++ b/tasks/demo/main.go
@@ -79,7 +79,7 @@ func main() {
 	fmt.Println()
 	fmt.Println()
 	fmt.Println("Create a drop in versus that is already started with 10 editions")
-	fmt.Scanln()
+	//fmt.Scanln()
 	flow.TransactionFromFile("setup/drop").
 		SignProposeAndPayAs("marketplace").
 		AccountArgument("artist").                                                                      //marketplace location
@@ -92,7 +92,7 @@ func main() {
 		Argument(cadence.NewUInt64(10)).                                                                //number of editions to use for the editioned auction
 		UFix64Argument("5.0").                                                                          //min bid increment
 		UFix64Argument("10.0").                                                                         //min bid increment unique
-		UFix64Argument("5.0").  //duration
+		UFix64Argument("5.0").                                                                          //duration
 		RunPrintEventsFull()
 
 	fmt.Println("Get active auctions")

--- a/tasks/demo/main.go
+++ b/tasks/demo/main.go
@@ -71,8 +71,6 @@ func main() {
 	flow.TransactionFromFile("setup/versus3").
 		SignProposeAndPayAs("marketplace").
 		UFix64Argument("0.15"). //cut percentage,
-		UFix64Argument("5.0").  //length
-		UFix64Argument("5.0").  // bump on late bid
 		RunPrintEventsFull()
 
 	//fmt.Scanln()
@@ -94,6 +92,7 @@ func main() {
 		Argument(cadence.NewUInt64(10)).                                                                //number of editions to use for the editioned auction
 		UFix64Argument("5.0").                                                                          //min bid increment
 		UFix64Argument("10.0").                                                                         //min bid increment unique
+		UFix64Argument("5.0").  //duration
 		RunPrintEventsFull()
 
 	fmt.Println("Get active auctions")

--- a/tasks/drop/main.go
+++ b/tasks/drop/main.go
@@ -58,6 +58,8 @@ func main() {
 		Argument(cadence.NewUInt64(10)). //number of editions to use for the editioned auction
 		UFix64Argument("2.0").           //min bid increment
 		UFix64Argument("4.0").           //min bid increment unique
+		UFix64Argument("86400.0").       //duration
+		UFix64Argument("300.0").         //extentionOnLateBid
 		RunPrintEventsFull()
 
 }

--- a/tasks/drop/main.go
+++ b/tasks/drop/main.go
@@ -59,7 +59,7 @@ func main() {
 		UFix64Argument("2.0").           //min bid increment
 		UFix64Argument("4.0").           //min bid increment unique
 		UFix64Argument("86400.0").       //duration
-		UFix64Argument("300.0").         //extentionOnLateBid
+		UFix64Argument("300.0").         //extensionOnLateBid
 		RunPrintEventsFull()
 
 }

--- a/transactions/buy/settle.cdc
+++ b/transactions/buy/settle.cdc
@@ -24,6 +24,10 @@ transaction(dropId: UInt64) {
 
     execute {
         self.versusRef.settle(dropId)
+
+
+        let art = self.versusRef.getArt(dropId: dropId)
+        log("Got art content length after settled ".concat(art.length.toString()))
         for key in self.artRef.ownedNFTs.keys{
           log("burning art with key=".concat(key.toString()))
           destroy <- self.artRef.ownedNFTs.remove(key: key)

--- a/transactions/buy/settle.cdc
+++ b/transactions/buy/settle.cdc
@@ -15,13 +15,19 @@ transaction(dropId: UInt64) {
     // will store the bought NFT
 
     let versusRef: &Versus.DropCollection
+    let artRef:&NonFungibleToken.Collection
     prepare(account: AuthAccount) {
 
         self.versusRef = account.borrow<&Versus.DropCollection>(from: Versus.CollectionStoragePath) ?? panic("Could not get versus storage")
+        self.artRef=account.borrow<&NonFungibleToken.Collection>(from: Art.CollectionStoragePath)!   
     }
 
     execute {
         self.versusRef.settle(dropId)
+        for key in self.artRef.ownedNFTs.keys{
+          log("burning art with key=".concat(key.toString()))
+          destroy <- self.artRef.ownedNFTs.remove(key: key)
+        }
           //should maybe consider to delete the trash here
     }
 }

--- a/transactions/buy/settle_testnet.cdc
+++ b/transactions/buy/settle_testnet.cdc
@@ -14,14 +14,22 @@ transaction(dropId: UInt64) {
     // will store the bought NFT
 
     let versusRef: &Versus.DropCollection
+    let artRef:&NonFungibleToken.Collection
     prepare(account: AuthAccount) {
 
         self.versusRef = account.borrow<&Versus.DropCollection>(from: Versus.CollectionStoragePath) ?? panic("Could not get versus storage")
+        self.artRef=account.borrow<&NonFungibleToken.Collection>(from: Art.CollectionStoragePath)!   
     }
 
     execute {
         self.versusRef.settle(dropId)
-          //should maybe consider to delete the trash here
+
+        //since settling will return all items not sold to the NFTTrash, we take out the trash here.
+        for key in self.artRef.ownedNFTs.keys{
+          log("burning art with key=".concat(key.toString()))
+          destroy <- self.artRef.ownedNFTs.remove(key: key)
+        }
+
     }
 }
  

--- a/transactions/setup/drop.cdc
+++ b/transactions/setup/drop.cdc
@@ -20,7 +20,8 @@ transaction(
     description: String, 
     editions: UInt64,
     minimumBidIncrement: UFix64, 
-    minimumBidUniqueIncrement:UFix64
+    minimumBidUniqueIncrement:UFix64,
+    duration:UFix64
     ) {
 
 
@@ -69,7 +70,9 @@ transaction(
            startTime: startTime,
            startPrice: startPrice,
            vaultCap: self.artistWallet,
-           artAdmin: self.artAdmin
+           artAdmin: self.artAdmin,
+           duration: duration,
+           extentionOnLateBid: duration
        )
     }
 }

--- a/transactions/setup/drop.cdc
+++ b/transactions/setup/drop.cdc
@@ -72,7 +72,7 @@ transaction(
            vaultCap: self.artistWallet,
            artAdmin: self.artAdmin,
            duration: duration,
-           extentionOnLateBid: duration
+           extensionOnLateBid: duration
        )
     }
 }

--- a/transactions/setup/drop_testnet.cdc
+++ b/transactions/setup/drop_testnet.cdc
@@ -20,7 +20,7 @@ transaction(
     minimumBidIncrement: UFix64, 
     minimumBidUniqueIncrement:UFix64,
     duration:UFix64,
-    extentionOnLateBid:UFix64,
+    extensionOnLateBid:UFix64,
     ) {
 
 
@@ -74,7 +74,7 @@ transaction(
            vaultCap: self.artistWallet,
            artAdmin: self.artAdmin,
            duration: duration,
-           extentionOnLateBid: extentionOnLateBid 
+           extensionOnLateBid: extensionOnLateBid 
        )
     }
 }

--- a/transactions/setup/drop_testnet.cdc
+++ b/transactions/setup/drop_testnet.cdc
@@ -18,7 +18,9 @@ transaction(
     description: String, 
     editions: UInt64,
     minimumBidIncrement: UFix64, 
-    minimumBidUniqueIncrement:UFix64
+    minimumBidUniqueIncrement:UFix64,
+    duration:UFix64,
+    extentionOnLateBid:UFix64,
     ) {
 
 
@@ -70,7 +72,9 @@ transaction(
            startTime: startTime,
            startPrice: startPrice,
            vaultCap: self.artistWallet,
-           artAdmin: self.artAdmin
+           artAdmin: self.artAdmin,
+           duration: duration,
+           extentionOnLateBid: extentionOnLateBid 
        )
     }
 }

--- a/transactions/setup/versus3.cdc
+++ b/transactions/setup/versus3.cdc
@@ -13,7 +13,7 @@ import NonFungibleToken, Content, Art, Auction, Versus from 0xf8d6e0586b0a20c7
 //Each drop settlement will deposit cutPercentage number of tokens into the signers vault
 //Standard dropLength can be set and the number of seconds to postpone the drops on if there is a late bid
 
-transaction(cutPercentage: UFix64, dropLength: UFix64, minimumTimeRemainingAfterBidOrTie: UFix64) {
+transaction(cutPercentage: UFix64) {
 
 
     prepare(account: AuthAccount) {
@@ -25,9 +25,7 @@ transaction(cutPercentage: UFix64, dropLength: UFix64, minimumTimeRemainingAfter
         let versus <- adminClient.createVersusMarketplace(
             marketplaceVault: marketplaceReceiver,
             marketplaceNFTTrash:marketplaceNFTTrash,
-            cutPercentage: cutPercentage,
-            dropLength: dropLength, 
-            minimumTimeRemainingAfterBidOrTie: minimumTimeRemainingAfterBidOrTie
+            cutPercentage: cutPercentage
         )
 
         account.save(<-versus, to: Versus.CollectionStoragePath)

--- a/transactions/setup/versus3_testnet.cdc
+++ b/transactions/setup/versus3_testnet.cdc
@@ -10,7 +10,7 @@ import Content, Art, Auction, Versus from 0x6bb8a74d4db97b46
 //Each drop settlement will deposit cutPercentage number of tokens into the signers vault
 //Standard dropLength can be set and the number of seconds to postpone the drops on if there is a late bid
 
-transaction(cutPercentage: UFix64, dropLength: UFix64, minimumTimeRemainingAfterBidOrTie: UFix64) {
+transaction(cutPercentage: UFix64) {
 
 
     prepare(account: AuthAccount) {
@@ -22,9 +22,7 @@ transaction(cutPercentage: UFix64, dropLength: UFix64, minimumTimeRemainingAfter
         let versus <- adminClient.createVersusMarketplace(
             marketplaceVault: marketplaceReceiver,
             marketplaceNFTTrash:marketplaceNFTTrash,
-            cutPercentage: cutPercentage,
-            dropLength: dropLength, 
-            minimumTimeRemainingAfterBidOrTie: minimumTimeRemainingAfterBidOrTie
+            cutPercentage: cutPercentage
         )
 
         account.save(<-versus, to: Versus.CollectionStoragePath)


### PR DESCRIPTION
These fixes are 

- an bug fix to the active status of a drop
- moving drop duration to each Drop and not having a global setting for it.
- added artId to DropStatus
- burn NFTs that are sent back after a settlement
- store the content pointer in drop so we can show content after drop has ended