### PR TITLE
Partial withdraw funds

### DIFF
--- a/contracts/Auction.cdc
+++ b/contracts/Auction.cdc
@@ -266,7 +266,7 @@ pub contract Auction {
                 return self.bidVault.balance
             }
             return 0.0
-        }
+        }n
 
         // This method should probably use preconditions more
         pub fun placeBid(bidTokens: @FungibleToken.Vault, vaultCap: Capability<&{FungibleToken.Receiver}>, collectionCap: Capability<&{Art.CollectionPublic}>) {
@@ -278,15 +278,19 @@ pub contract Auction {
 
             let bidderAddress=vaultCap.borrow()!.owner!.address
 
-            if bidTokens.balance < self.minNextBid() + self.currentBidForUser(address:bidderAddress) {
-                panic("bid amount must be larger or equal to the current price + minimum bid increment - your current bid (if any)")
+            let amountYouAreBidding= bidTokens.balance + self.currentBidForUser(address: bidderAddress)
+            let minNextBid=self.minNextBid()
+            if amountYouAreBidding < minNextBid {
+                panic("bid amount + (your current bid) must be larger or equal to the current price + minimum bid increment ".concat(amountYouAreBidding.toString()).concat(" < ").concat(minNextBid.toString()))
              }
 
             if self.bidder() != bidderAddress {
-              if let vaultCap = self.recipientVaultCap {
-                  self.sendBidTokens(self.recipientVaultCap!)
-              } else {
-                  panic("unable to get recipient Vault capability")
+              if self.bidVault.balance != 0.0 {
+                if let vaultCap = self.recipientVaultCap {
+                    self.sendBidTokens(self.recipientVaultCap!)
+                } else {
+                    panic("unable to get recipient Vault capability")
+                }
               }
             }
 

--- a/contracts/Auction.cdc
+++ b/contracts/Auction.cdc
@@ -266,7 +266,7 @@ pub contract Auction {
                 return self.bidVault.balance
             }
             return 0.0
-        }n
+        }
 
         // This method should probably use preconditions more
         pub fun placeBid(bidTokens: @FungibleToken.Vault, vaultCap: Capability<&{FungibleToken.Receiver}>, collectionCap: Capability<&{Art.CollectionPublic}>) {

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -199,6 +199,26 @@ pub contract Versus {
            } 
         }
         
+         priv fun getAuction(auctionId:UInt64): &Auction.AuctionItem {
+            let dropStatus = self.getDropStatus()
+            if self.uniqueAuction.auctionID == auctionId {
+                return &self.uniqueAuction as &Auction.AuctionItem
+            } else {
+                let editionStatus=dropStatus.editionsStatuses[auctionId]!
+                return &self.editionAuctions.auctionItems[auctionId] as &Auction.AuctionItem
+            }
+         }
+
+         pub fun currentBidForUser(
+            auctionId: UInt64,
+            address:Address
+        ) : UFix64 {
+
+            let auction=self.getAuction(auctionId:auctionId)
+            return auction.currentBidForUser(address: address)
+           
+        }
+
         //place a bid on a given auction
         pub fun placeBid(
             auctionId:UInt64,
@@ -352,6 +372,7 @@ pub contract Versus {
     //An resource interface that everybody can access through a public capability.
     pub resource interface PublicDrop {
 
+        pub fun currentBidForUser( dropId: UInt64, auctionId: UInt64, address:Address) : UFix64
         pub fun getAllStatuses(): {UInt64: DropStatus}
         pub fun getStatus(dropId: UInt64): DropStatus
 
@@ -504,6 +525,17 @@ pub contract Versus {
         pub fun settle(_ dropId: UInt64) {
             self.getDrop(dropId).settle(cutPercentage: self.cutPercentage, vault: self.marketplaceVault)
        }
+
+        pub fun currentBidForUser(
+            dropId: UInt64,
+            auctionId: UInt64,
+            address:Address
+        ) : UFix64 {
+            return  self.getDrop(dropId).currentBidForUser(
+                auctionId: auctionId, 
+                address:address
+            )
+        }
 
         //place a bid, will just delegate to the method in the drop collection
         pub fun placeBid(

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -257,12 +257,12 @@ pub contract Versus {
                 self.extendDropWith(UFix64(extendWith))
             }
 
-            let bidPrice = bidTokens.balance
             let bidder=vaultCap.borrow()!.owner!.address
+            let currentBidForUser= self.currentBidForUser(auctionId: auctionId, address: bidder)
+            let bidPrice = bidTokens.balance + currentBidForUser
 
             var edition:String="1 of 1"
 
-            var price:UFix64=0.0
             //the bid is on a unique auction so we place the bid there
             if self.uniqueAuction.auctionID == auctionId {
                 let auctionRef = &self.uniqueAuction as &Auction.AuctionItem

--- a/contracts/Versus.cdc
+++ b/contracts/Versus.cdc
@@ -372,7 +372,7 @@ pub contract Versus {
     //An resource interface that everybody can access through a public capability.
     pub resource interface PublicDrop {
 
-        pub fun currentBidForUser( dropId: UInt64, auctionId: UInt64, address:Address) : UFix64
+        pub fun currentBidForUser(dropId: UInt64, auctionId: UInt64, address:Address) : UFix64
         pub fun getAllStatuses(): {UInt64: DropStatus}
         pub fun getStatus(dropId: UInt64): DropStatus
 

--- a/tasks/demo/main.go
+++ b/tasks/demo/main.go
@@ -95,6 +95,7 @@ func main() {
 
 	flow.TransactionFromFile("setup/mint_tokens").SignProposeAndPayAsService().AccountArgument("buyer1").UFix64Argument("1000.0").RunPrintEventsFull()
 
+	fmt.Scanln()
 	flow.TransactionFromFile("buy/bid").
 		SignProposeAndPayAs("buyer1").
 		RawAccountArgument("0xf8d6e0586b0a20c7"). //we use raw argument here because of a limitation on how go-with-the-flow is built
@@ -102,6 +103,15 @@ func main() {
 		Argument(cadence.UInt64(11)).             //id of unique auction auction to bid on
 		UFix64Argument("10.00").                  //amount to bid
 		RunPrintEventsFull()
+
+	flow.TransactionFromFile("buy/bid").
+		SignProposeAndPayAs("buyer1").
+		RawAccountArgument("0xf8d6e0586b0a20c7"). //we use raw argument here because of a limitation on how go-with-the-flow is built
+		Argument(cadence.UInt64(1)).              //id of drop
+		Argument(cadence.UInt64(11)).             //id of unique auction auction to bid on
+		UFix64Argument("12.00").                  //amount to bid
+		RunPrintEventsFull()
+	fmt.Scanln()
 
 	fmt.Println()
 	fmt.Println()

--- a/tasks/demo/main.go
+++ b/tasks/demo/main.go
@@ -95,7 +95,6 @@ func main() {
 
 	flow.TransactionFromFile("setup/mint_tokens").SignProposeAndPayAsService().AccountArgument("buyer1").UFix64Argument("1000.0").RunPrintEventsFull()
 
-	fmt.Scanln()
 	flow.TransactionFromFile("buy/bid").
 		SignProposeAndPayAs("buyer1").
 		RawAccountArgument("0xf8d6e0586b0a20c7"). //we use raw argument here because of a limitation on how go-with-the-flow is built
@@ -103,13 +102,14 @@ func main() {
 		Argument(cadence.UInt64(11)).             //id of unique auction auction to bid on
 		UFix64Argument("10.00").                  //amount to bid
 		RunPrintEventsFull()
+	fmt.Scanln()
 
 	flow.TransactionFromFile("buy/bid").
 		SignProposeAndPayAs("buyer1").
 		RawAccountArgument("0xf8d6e0586b0a20c7"). //we use raw argument here because of a limitation on how go-with-the-flow is built
 		Argument(cadence.UInt64(1)).              //id of drop
 		Argument(cadence.UInt64(11)).             //id of unique auction auction to bid on
-		UFix64Argument("12.00").                  //amount to bid
+		UFix64Argument("30.00").                  //amount to bid
 		RunPrintEventsFull()
 	fmt.Scanln()
 

--- a/transactions/buy/bid.cdc
+++ b/transactions/buy/bid.cdc
@@ -17,6 +17,7 @@ transaction(marketplace: Address, dropId: UInt64, auctionId: UInt64, bidAmount: 
 
     let vaultCap: Capability<&{FungibleToken.Receiver}>
     let collectionCap: Capability<&{Art.CollectionPublic}> 
+    let versusRef:&{Versus.PublicDrop}
     // Vault that will hold the tokens that will be used
     // to buy the NFT
     let temporaryVault: @FungibleToken.Vault
@@ -42,20 +43,18 @@ transaction(marketplace: Address, dropId: UInt64, auctionId: UInt64, bidAmount: 
         let vaultRef = account.borrow<&FungibleToken.Vault>(from: /storage/flowTokenVault)
             ?? panic("Could not borrow owner's Vault reference")
 
+        let seller = getAccount(marketplace)
+        self.versusRef = seller.getCapability(Versus.CollectionPublicPath).borrow<&{Versus.PublicDrop}>() ?? panic("Could not borrow seller's sale reference")
+
+        let currentBid=self.versusRef.currentBidForUser(dropId: dropId, auctionId: auctionId, address: account.address)
+        //if your capability is the leader you only have to send in the difference
+
         // withdraw tokens from the buyer's Vault
-        self.temporaryVault <- vaultRef.withdraw(amount: bidAmount)
+        self.temporaryVault <- vaultRef.withdraw(amount: bidAmount - currentBid)
     }
 
     execute {
-        // get the read-only account storage of the seller
-        let seller = getAccount(marketplace)
-
-        // get the reference to the seller's sale
-        let versusRef = seller.getCapability(Versus.CollectionPublicPath)
-                         .borrow<&{Versus.PublicDrop}>()
-                         ?? panic("Could not borrow seller's sale reference")
-
-        versusRef.placeBid(dropId: dropId, auctionId: auctionId, bidTokens: <- self.temporaryVault, vaultCap: self.vaultCap, collectionCap: self.collectionCap)
+        self.versusRef.placeBid(dropId: dropId, auctionId: auctionId, bidTokens: <- self.temporaryVault, vaultCap: self.vaultCap, collectionCap: self.collectionCap)
     }
 }
  


### PR DESCRIPTION
If a user is outbidding himself he needed to supply the new total amount of flow for each bid. This PR changes the code so that the user only needs to supply the difference between its own bid in an auction and the new bid. 
